### PR TITLE
random function with no args

### DIFF
--- a/q5.js
+++ b/q5.js
@@ -1798,8 +1798,10 @@ function Q5(scope){
         }else{
           return rng1.rand()*a;
         }
-      }else{
+      }else if (Array.isArray(a)) {
         return a[~~(a.length*rng1.rand())];
+      }else{
+        return Math.random();
       }
     }
     $.randomGenerator = function(method){


### PR DESCRIPTION
I was experimenting with the library and stumbled upon random function that was not working without arguments. According to p5js version it should return a pseudo-random value between [0, 1). 

[p5js random function reference](https://p5js.org/reference/#/p5/random)

Not the function checks if it is a number or an array and if it not any of it, returns the random value in range  [0, 1).