### PR TITLE
Added return of canvas element to createCanvas

### DIFF
--- a/q5.js
+++ b/q5.js
@@ -231,6 +231,7 @@ function Q5(scope){
       $.canvas.width = width;
       $.canvas.height = height;
       defaultStyle();
+      return $.canvas
     }
 
     $.resizeCanvas = function(width, height){


### PR DESCRIPTION
For parity with p5js
And so the consumer does not need to know implementation details of obtaining a ref to the element

NOTE: not added to `q5.min.js` as I don't know how the file is minified.