### PR TITLE
add missing pow

### DIFF
--- a/q5.js
+++ b/q5.js
@@ -331,6 +331,7 @@ function Q5(scope){
     $.acos = Math.acos;
     $.atan = Math.atan;
     $.atan2 = Math.atan2;
+    $.pow = Math.pow;
 
     //================================================================
     // VECTOR


### PR DESCRIPTION
I found that q5 missing a pow, so I add it.

same implementation with https://github.com/processing/p5.js/blob/5f3c9b40193f012bfeb8c3e5de5877fe70c8ee2a/src/math/calculation.js#L640