### PR TITLE
fix: support touchStarted, touchEnded, touchMoved

### DIFF
--- a/q5.js
+++ b/q5.js
@@ -2019,7 +2019,7 @@ function Q5(scope){
       "setup","draw","preload",
       "mouseMoved","mousePressed","mouseReleased","mouseDragged","mouseClicked",
       "keyPressed","keyReleased","keyTyped",
-      "touchStarted","touchEnded",
+      "touchStarted","touchEnded","touchMoved"
     ];
     for (let k of eventNames){
       let intern = "_"+k+"Fn";
@@ -2155,9 +2155,9 @@ function Q5(scope){
       };
     }
     function isTouchUnaware(){
-      return $.touchStarted
-         &&  $.touchMoved
-         &&  $.touchEnded
+      return $._touchStartedFn.isPlaceHolder
+         &&  $._touchMovedFn.isPlaceHolder
+         &&  $._touchEndedFn.isPlaceHolder
     }
     $.canvas.ontouchstart = function(event){
       $.touches = [...event.touches].map(getTouchInfo);
@@ -2172,7 +2172,7 @@ function Q5(scope){
           event.preventDefault();
         }
       }
-      if (!$.touchStarted(event)){
+      if (!$._touchStartedFn(event)){
         event.preventDefault();
       }
 
@@ -2190,7 +2190,7 @@ function Q5(scope){
           event.preventDefault();
         }
       }
-      if (!$.touchMoved(event)){
+      if (!$._touchMovedFn(event)){
         event.preventDefault();
       }
 
@@ -2207,7 +2207,7 @@ function Q5(scope){
           event.preventDefault();
         }
       }
-      if (!$.touchEnded(event)){
+      if (!$._touchEndedFn(event)){
         event.preventDefault();
       }
     }

--- a/q5.js
+++ b/q5.js
@@ -2155,12 +2155,12 @@ function Q5(scope){
       };
     }
     function isTouchUnaware(){
-      return $._touchStarted.isPlaceHolder
-         &&  $._touchMoved.isPlaceHolder
-         &&  $._touchEnded.isPlaceHolder
+      return $.touchStarted
+         &&  $.touchMoved
+         &&  $.touchEnded
     }
     $.canvas.ontouchstart = function(event){
-      $.touches = event.touches.map(getTouchInfo);
+      $.touches = [...event.touches].map(getTouchInfo);
       if (isTouchUnaware()){
         $.pmouseX = $.mouseX;
         $.pmouseY = $.mouseY;
@@ -2172,13 +2172,13 @@ function Q5(scope){
           event.preventDefault();
         }
       }
-      if (!$._touchStartedFn(event)){
+      if (!$.touchStarted(event)){
         event.preventDefault();
       }
 
     }
     $.canvas.ontouchmove = function(event){
-      $.touches = event.touches.map(getTouchInfo);
+      $.touches = [...event.touches].map(getTouchInfo);
       if (isTouchUnaware()){
         $.pmouseX = $.mouseX;
         $.pmouseY = $.mouseY;
@@ -2190,13 +2190,13 @@ function Q5(scope){
           event.preventDefault();
         }
       }
-      if (!$._touchMovedFn(event)){
+      if (!$.touchMoved(event)){
         event.preventDefault();
       }
 
     }
     $.canvas.ontouchend = $.canvas.ontouchcancel = function(event){
-      $.touches = event.touches.map(getTouchInfo);
+      $.touches = [...event.touches].map(getTouchInfo);
       if (isTouchUnaware()){
         $.pmouseX = $.mouseX;
         $.pmouseY = $.mouseY;
@@ -2207,7 +2207,7 @@ function Q5(scope){
           event.preventDefault();
         }
       }
-      if (!$._touchEndedFn(event)){
+      if (!$.touchEnded(event)){
         event.preventDefault();
       }
     }


### PR DESCRIPTION
fixes #22 

Hey @LingDong- thanks for this awesome lib. Needed to get touch working for mobile and thought I'd share my solution back.

You use this by setting the handlers on q5:

```
const q5 = new Q5();
q5.touchStarted = () => {}
q5.touchMoved = () => {}
q5.touchEnded = () => {}
```